### PR TITLE
`import public` everywhere, flatten out a case-match

### DIFF
--- a/src/Http.idr
+++ b/src/Http.idr
@@ -1,32 +1,24 @@
 module Http
 
-import Http.Uri
-import Http.Error
-import Http.RawResponse
-import Http.Request
-import Http.Response
-import Data.SortedMap
-import Data.Vect
-import Network.Socket
+import public Http.Uri
+import public Http.Error
+import public Http.RawResponse
+import public Http.Request
+import public Http.Response
+import public Data.SortedMap
+import public Data.Vect
+import public Network.Socket
 
 %access export
 
 private
 sendRequest : Request a -> IO (Either HttpError (RawResponse String))
 sendRequest req = do
-    --print (resolveRequest req)
-    case !(socket AF_INET Stream 0) of
-      Left err   => pure (Left $ HttpSocketError err)
-      Right sock =>
-        case !(connect sock (Hostname host) port) of
-          0 =>
-            case !(send sock (resolveRequest req)) of
-              Left err => pure (Left $ HttpSocketError err)
-              Right _  =>
-                case !(recv sock 65536) of
-                  Left err       => pure (Left $ HttpSocketError err)
-                  Right (str, _) => pure (Right (MkRawResponse str))
-          err => pure (Left $ HttpSocketError err)
+    Right sock <- socket AF_INET Stream 0 | Left err => pure (Left $ HttpSocketError err)
+    0 <- connect sock (Hostname host) port | err => pure (Left $ HttpSocketError err)
+    Right _ <- send sock (resolveRequest req) | Left err => pure (Left $ HttpSocketError err)
+    Right (str, _) <- recv sock 65536 | Left err => pure (Left $ HttpSocketError err)
+    pure (Right (MkRawResponse str))
   where
     host : String
     host = uriHost . uriAuth . uri $ req

--- a/src/Http/Error.idr
+++ b/src/Http/Error.idr
@@ -1,6 +1,6 @@
 module Http.Error
 
-import Network.Socket
+import public Network.Socket
 
 %access public export
 

--- a/src/Http/Request.idr
+++ b/src/Http/Request.idr
@@ -1,7 +1,7 @@
 module Http.Request
 
-import Data.SortedMap
-import Http.Uri
+import public Data.SortedMap
+import public Http.Uri
 
 %access export
 

--- a/src/Http/Response.idr
+++ b/src/Http/Response.idr
@@ -5,10 +5,10 @@ import Lightyear.Combinators
 import Lightyear.Char
 import Lightyear.Strings
 
-import Data.SortedMap
-import Http.Request
-import Http.RawResponse
-import Http.Error
+import public Data.SortedMap
+import public Http.Request
+import public Http.RawResponse
+import public Http.Error
 
 import Data.Bytes as B
 
@@ -107,4 +107,4 @@ responseParser = do
 parseResponse : RawResponse String -> Either HttpError (Response String)
 parseResponse (MkRawResponse input) = case parse responseParser input of
                                            Left err => Left $ HttpParseError err
-                                           Right re => Right re 
+                                           Right re => Right re

--- a/src/Http/Uri.idr
+++ b/src/Http/Uri.idr
@@ -1,6 +1,6 @@
 module Http.Uri
 
-import Data.Vect
+import public Data.Vect
 
 %access public export
 


### PR DESCRIPTION
Clients who import Http should not need to re-import all the necessary
requirements. Also, the pipe-syntax helps flatten out nested cases and
makes code more readable.