### PR TITLE
Make compatible with the latest idris-bytes

### DIFF
--- a/src/Http/Response.idr
+++ b/src/Http/Response.idr
@@ -85,7 +85,7 @@ parseBodyChunkEncoded = do
     parseBody x = do
       n <- pack <$> many (oneOf "\n\r")
       s <- pack <$> some (noneOf "\n\r")
-      let len = B.length (B.fromString (s ++ n))
+      let len = toIntNat (B.length (B.fromString (s ++ n)))
       if x - len < 0 then fail ("Somehow the String " ++ s ++ n ++ " is longer than " ++ show x)
       else if x - len == 0 then crlf *> pure s
                            else map (s ++) $ parseBody (x - len)


### PR DESCRIPTION
Data.Bytes.length now returns Nat: https://github.com/ziman/idris-bytes/pull/2